### PR TITLE
Add authors & number of new articles to email

### DIFF
--- a/arxivnotify.py
+++ b/arxivnotify.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # ArXiV Notify script
-# This program is free software: you can redistribute it and/or p/nnnnnnjjjjjodify
+# This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
@@ -157,3 +157,4 @@ try:
             raise RuntimeError("Mail Error: ", RETURN_VAL.text)
 except:
     raise RuntimeError('Arxiv notifier bot wasn\'t able to send an email! Check your mailgun API key and Root. HTML ERROR: {} {}'.format(RETURN_VAL.status_code, RETURN_VAL.text))
+


### PR DESCRIPTION
Great tool!
I made a few changes this morning that I thought you might also want:

* Added the authors beneath the title
* Made the title the clickable link
* Added the number of new articles to the subject line so that I can ignore the email if it's 0.

Here's an example email:
![Screenshot 2020-02-04 at 11 31 46 AM](https://user-images.githubusercontent.com/1455579/73779739-0b3a3880-4742-11ea-973f-a108c201c966.png)
